### PR TITLE
add soversion for libtouche shared library

### DIFF
--- a/subprojects/libtouche/meson.build
+++ b/subprojects/libtouche/meson.build
@@ -30,6 +30,7 @@ libtouche = shared_library(
   include_directories : inc,
   sources: sources,
   dependencies: dependencies,
+  soversion: '0',
   install: true
 )
 


### PR DESCRIPTION
Hello!
Good practice for shared libraries is to give them a soversion. 
I suggest following good practices. 